### PR TITLE
Adds group_project identifier to workgroup submissions. 

### DIFF
--- a/group_project/group_project.py
+++ b/group_project/group_project.py
@@ -227,6 +227,7 @@ class GroupProjectBlock(XBlock):
             self.project_api.submit_workgroup_review_items(
                 self.xmodule_runtime.anonymous_student_id,
                 group_id,
+                self.id,
                 submissions
             )
 
@@ -263,7 +264,8 @@ class GroupProjectBlock(XBlock):
 
         feedback = self.project_api.get_workgroup_review_items(
             self.xmodule_runtime.anonymous_student_id,
-            group_id
+            group_id,
+            self.id
         )
 
         # pivot the data to show question -> answer
@@ -293,7 +295,8 @@ class GroupProjectBlock(XBlock):
     def load_my_group_feedback(self, request, suffix=''):
         workgroup_id = self.workgroup['id']
         feedback = self.project_api.get_workgroup_review_items_for_group(
-            workgroup_id
+            workgroup_id,
+            self.id
         )
 
         results = {}

--- a/group_project/project_api.py
+++ b/group_project/project_api.py
@@ -157,13 +157,13 @@ class ProjectAPI(object):
                 }
                 self.create_peer_review_assessment(question_data)
 
-    def get_workgroup_review_items(self, reviewer_id, group_id):
+    def get_workgroup_review_items(self, reviewer_id, group_id, content_id):
         group_review_items = self.get_workgroup_review_items_for_group(group_id)
-        return [gri for gri in group_review_items if gri['reviewer'] == reviewer_id]
+        return [gri for gri in group_review_items if gri['reviewer'] == reviewer_id and gri['content_id'] == content_id]
 
-    def submit_workgroup_review_items(self, reviewer_id, group_id, data):
+    def submit_workgroup_review_items(self, reviewer_id, group_id, content_id, data):
         # get any data already there
-        current_data = {ri['question']: ri for ri in self.get_workgroup_review_items(reviewer_id, group_id)}
+        current_data = {ri['question']: ri for ri in self.get_workgroup_review_items(reviewer_id, group_id, content_id)}
         for k,v in data.iteritems():
             if k in current_data:
                 question_data = current_data[k]
@@ -185,6 +185,7 @@ class ProjectAPI(object):
                     "answer": v,
                     "workgroup": group_id,
                     "reviewer": reviewer_id,
+                    "content_id": content_id,
                 }
                 self.create_workgroup_review_assessment(question_data)
 


### PR DESCRIPTION
This allows for separate xblock definitions to use the same question id for activity-specific fields without sharing data. Also, it allows for the progress page to understand which values belong to which activity.
