### PR TITLE
Addresses MCKIN-2588. Defer to foundation's class for positioning.

### DIFF
--- a/group_project/public/css/group_project.css
+++ b/group_project/public/css/group_project.css
@@ -254,9 +254,8 @@
 }
 
 .upload_form .xblock-reveal.reveal-modal.open{
-  position: fixed;
-  top:30%;
-  left:50%;
+  max-height: 80%;
+  overflow: auto;
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
 Prevent the dialog from being too tall, and when the content is too tall, make it scrollable.
@marjev - can you take a look at this, sorry I stole it from you, but it was bugging me!
