### PR TITLE
(MCKIN-3055) Upload popup positioning fixed

### DIFF
--- a/group_project/public/css/group_project.css
+++ b/group_project/public/css/group_project.css
@@ -172,17 +172,22 @@
   padding: 10px 0;
   font-size: 14px;
 }
+.upload_form .upload_item .upload_input{
+  overflow: hidden;
+  padding-right: 5px;
+}
 .upload_form .upload_item input[type=text]{
-  width: 86%;
+  width: 100%;
   display: inline-block;
   background-color: transparent;
   color: #3384ca;
   margin-bottom: 0;
 }
 .upload_form .upload_item label{
-  width: 13%;
+  width: 75px;
   display: inline-block;
   text-align: right;
+  float: right;
 }
 .upload_form .upload_item label span{
   margin-bottom: 0;
@@ -254,6 +259,7 @@
 }
 
 .upload_form .xblock-reveal.reveal-modal.open{
+  position: fixed;
   max-height: 80%;
   overflow: auto;
   padding-bottom: 0;

--- a/group_project/templates/html/activity_section.html
+++ b/group_project/templates/html/activity_section.html
@@ -34,10 +34,12 @@
       {% for file_link in activity_section.upload_links %}
         <div class="upload_item">
           <div class="upload_title">{{ file_link.title }}</div>
-          <input class="{{ file_link.id }}_name" placeholder="Browse your computer to upload file..." disabled="disabled" type="text" {% if file_link.file_name %}value="{{ file_link.file_name }}" data-original-value="{{ file_link.file_name }}"{% endif %}/>
           <label for="{{ file_link.id }}">
             <span class="side button tiny radius {{ file_link.id }}_label">{% if file_link.location %}Update{% else %}Browse{% endif %}</span>
           </label>
+          <div class="upload_input">
+            <input class="{{ file_link.id }}_name" placeholder="Browse your computer to upload file..." disabled="disabled" type="text" {% if file_link.file_name %}value="{{ file_link.file_name }}" data-original-value="{{ file_link.file_name }}"{% endif %}/>
+          </div>
           <input style="display:none;" class="file_upload" name="{{ file_link.id }}" id="{{ file_link.id }}" type="file" />
           {% if file_link.description %}
             <div class="description">{{ file_link.description }}</div>


### PR DESCRIPTION
@martynjames 

I positioned the popup window as you suggested.

Also, I've changed the template for popup window and added a few updates to the css file, because the `browse` buttons were misaligned and/or cutoff in a weird manner. Please review those changes to see if there are some scenarios in which those wouldn't work.

I've checked that the solution goes along with the rest of the responsive design. I tried to avoid using `calc()` since it's not fully supported among the browsers and I know that's important on the MCKIN side.