### PR TITLE
(MCKIN-3164) Fix for issue in groupwork grading

### DIFF
--- a/group_project/project_api.py
+++ b/group_project/project_api.py
@@ -397,7 +397,7 @@ class ProjectAPI(object):
             )
         )
 
-        review_assignment_user_urls = ['{}{}users/'.format(self._api_server_address, ra["url"]) for ra in json.loads(response.read())]
+        review_assignment_user_urls = ['{}{}/users/'.format(self._api_server_address, ra["uri"]) for ra in json.loads(response.read())]
         reviewers = []
         for users_url in review_assignment_user_urls:
             reviewers.extend(json.loads(GET(users_url).read())["users"])


### PR DESCRIPTION
@antoviaque Can you please review this?

For some reason, calculate_grade returns None, which causes the MCKIN-3164 bug.

I'm not sure if you encountered this issue on xblock-group-project-v2.