### PR TITLE
(MCKIN-3164) Fixed issue in groupwork grading

### DIFF
--- a/group_project/group_activity.py
+++ b/group_project/group_activity.py
@@ -477,4 +477,3 @@ class GroupActivity(object):
     def import_xml_string(cls, xml, grading_override = False):
         doc_tree = ET.fromstring(xml)
         return cls(doc_tree, grading_override)
-

--- a/group_project/group_project.py
+++ b/group_project/group_project.py
@@ -308,7 +308,7 @@ class GroupProjectBlock(XBlock):
         review_item_data = self.project_api.get_workgroup_review_items_for_group(group_id, self.content_id)
         review_item_map = {make_key(r['question'], self.real_user_id(r['reviewer'])) : r['answer'] for r in review_item_data}
         all_reviewer_ids = set([self.real_user_id(r['reviewer']) for r in review_item_data])
-        group_reviewer_ids = [u["id"] for u in self.project_api.get_workgroup_reviewers(group_id)]
+        group_reviewer_ids = [u["id"] for u in self.project_api.get_workgroup_reviewers(group_id, self.content_id)]
         admin_reviewer_ids = [ar_id for ar_id in all_reviewer_ids if ar_id not in group_reviewer_ids]
 
         group_activity = GroupActivity.import_xml_string(self.data, self.is_admin_grader)

--- a/group_project/project_api.py
+++ b/group_project/project_api.py
@@ -388,7 +388,7 @@ class ProjectAPI(object):
         return workgroup_assignments
 
     @api_error_protect
-    def get_workgroup_reviewers(self, group_id):
+    def get_workgroup_reviewers(self, group_id, content_id):
         response = GET(
             '{}/{}/{}/groups'.format(
                 self._api_server_address,
@@ -397,7 +397,11 @@ class ProjectAPI(object):
             )
         )
 
-        review_assignment_user_urls = ['{}{}users/'.format(self._api_server_address, ra["url"]) for ra in json.loads(response.read())]
+        review_assignment_user_urls = [
+            '{}{}users/'.format(self._api_server_address, ra["url"])
+            for ra in json.loads(response.read())
+            if ra["data"]["xblock_id"] == content_id
+        ]
         reviewers = []
         for users_url in review_assignment_user_urls:
             reviewers.extend(json.loads(GET(users_url).read())["users"])


### PR DESCRIPTION
@antoviaque As I promised, here's a PR for [MCKIN-3164](https://edx-wiki.atlassian.net/browse/MCKIN-3164).

I discovered the issue here is that upon fetching the ids of peer reviewers, there isn't any filter for the content ID, which lead to the following behaviour. 
For each group work activity, peer reviewer ids from all of them were obtained. If at least one of the reviewers didn't complete the grading activity, all of the activities remained ungraded, since the code didn't calculate the grade (because of the single grade not being provided).

This fix will allow the calculation of the grade for those activities for which a user was provided a necessary amount of grades.