### PR TITLE
No need to prepend server address while making url for group users API

### DIFF
--- a/group_project/project_api.py
+++ b/group_project/project_api.py
@@ -398,7 +398,7 @@ class ProjectAPI(object):
         )
 
         review_assignment_user_urls = [
-            '{}{}users/'.format(self._api_server_address, ra["url"])
+            '{}users/'.format(ra["url"])
             for ra in json.loads(response.read())
             if ra["data"]["xblock_id"] == content_id
         ]


### PR DESCRIPTION
`Worgroup/{workgroup_id}/groups/` API is now returning absolute url of group instead of relative url as result of it we don't need to prefix server address to it otherwise it makes url like this `http://127.0.0.1:8000http://127.0.0.1:8000/api/server/groups/12/users/`.

@antoviaque can you review this small modification?
