### PR TITLE
Revert "(MCKIN-3050) Enabling TA view even when a TA is a group member"

### DIFF
--- a/group_project/api_error.py
+++ b/group_project/api_error.py
@@ -40,7 +40,6 @@ class ApiError(Exception):
     def __str__(self):
         return "ApiError '{}' ({})".format(self.message, self.code)
 
-
 def api_error_protect(func):
     '''
     Decorator which will raise an ApiError for api calls

--- a/group_project/group_activity.py
+++ b/group_project/group_activity.py
@@ -2,11 +2,11 @@ import xml.etree.ElementTree as ET
 from datetime import date
 import copy
 import json
+from django.template.loader import render_to_string
 from pkg_resources import resource_filename
 
 from utils import render_template
 from .project_api import _build_date_field
-
 
 def outer_html(node):
     if node is None:
@@ -14,14 +14,12 @@ def outer_html(node):
 
     return ET.tostring(node, 'utf-8', 'html').strip()
 
-
 def inner_html(node):
     if node is None:
         return None
 
     tag_length = len(node.tag)
     return outer_html(node)[tag_length+2:-1*(tag_length+3)]
-
 
 class DottableDict(dict):
     def __init__(self, *args, **kwargs):
@@ -150,7 +148,6 @@ class ActivityAssessment(object):
 
         return html
 
-
 class ActivitySection(object):
 
     def __init__(self, doc_tree, component, activity):
@@ -221,6 +218,7 @@ class ActivitySection(object):
         if self.upload_dialog:
             return inner_html(self.content)
         return None
+
 
     @property
     def export_xml(self):
@@ -345,7 +343,7 @@ class GroupActivity(object):
         split_string = date_string.split('/')
         return date(int(split_string[2]), int(split_string[0]), int(split_string[1]))
 
-    def __init__(self, doc_tree, grading_override=False):
+    def __init__(self, doc_tree, grading_override = False):
 
         self.resources = []
         self.submissions = []
@@ -449,6 +447,7 @@ class GroupActivity(object):
             elif ac.open_date and ac.open_date <= date.today():
                 default_stage = ac.id
 
+
         next_step = None
         for ac in reversed(self.activity_components):
             step_map[ac.id]["next"] = next_step
@@ -475,6 +474,6 @@ class GroupActivity(object):
         return cls(doc_tree)
 
     @classmethod
-    def import_xml_string(cls, xml, grading_override=False):
+    def import_xml_string(cls, xml, grading_override = False):
         doc_tree = ET.fromstring(xml)
         return cls(doc_tree, grading_override)

--- a/group_project/group_project.py
+++ b/group_project/group_project.py
@@ -51,7 +51,6 @@ log = logging.getLogger(__name__)
 def make_key(*args):
     return ":".join([str(a) for a in args])
 
-
 class OutsiderDisallowedError(Exception):
     def __init__(self, detail):
         self.value = detail
@@ -62,7 +61,6 @@ class OutsiderDisallowedError(Exception):
 
     def __unicode__(self):
         return u"Outsider Denied Access: {}".format(self.value)
-
 
 @XBlock.wants('notifications')
 @XBlock.wants('courseware_parent_info')
@@ -246,10 +244,6 @@ class GroupProjectBlock(XBlock):
             "ta_graded": (self.group_reviews_required_count < 1),
         }
 
-        user_prefs = self.project_api.get_user_preferences(self.user_id)
-        for activity_component in group_activity.activity_components:
-            activity_component.grading_override = True if "TA_REVIEW_WORKGROUP" in user_prefs else False
-
         fragment = Fragment()
         fragment.add_content(
             render_template('/templates/html/group_project.html', context))
@@ -382,6 +376,7 @@ class GroupProjectBlock(XBlock):
             # That's ok in this case
             if e.code != 409:
                 raise
+
 
     def update_upload_complete(self):
         for u in self.workgroup["users"]:
@@ -732,7 +727,7 @@ class GroupProjectBlock(XBlock):
         )
         html_output = render_template('/templates/html/review_submissions.html', {"group_activity": group_activity})
 
-        return webob.response.Response(body=json.dumps({"html": html_output}))
+        return webob.response.Response(body=json.dumps({"html":html_output}))
 
     @XBlock.handler
     def refresh_submission_links(self, request, suffix=''):
@@ -743,7 +738,7 @@ class GroupProjectBlock(XBlock):
         )
         html_output = render_template('/templates/html/submission_links.html', {"group_activity": group_activity})
 
-        return webob.response.Response(body=json.dumps({"html": html_output}))
+        return webob.response.Response(body=json.dumps({"html":html_output}))
 
     def get_courseware_info(self, courseware_parent_info_service):
         activity_name = self.display_name
@@ -772,6 +767,8 @@ class GroupProjectBlock(XBlock):
                 )
                 project_name = project_courseware_info['display_name']
                 project_location = project_courseware_info['location']
+
+
         except Exception, ex:
             # Can't look this up then log and just use the default
             # which is our display_name

--- a/group_project/json_requests.py
+++ b/group_project/json_requests.py
@@ -20,7 +20,6 @@ TIMEOUT = 20
 
 TRACE = True
 
-
 def trace_request_information(func):
     '''
     Decorator which will trace information

--- a/group_project/project_api.py
+++ b/group_project/project_api.py
@@ -16,7 +16,6 @@ SUBMISSION_API = '/'.join([API_PREFIX, 'submissions'])
 GROUP_API = '/'.join([API_PREFIX, 'groups'])
 COURSES_API = '/'.join([API_PREFIX, 'courses'])
 
-
 def _build_date_field(json_date_string_value):
     ''' converts json date string to date object '''
     try:
@@ -26,7 +25,6 @@ def _build_date_field(json_date_string_value):
         )
     except ValueError:
         return None
-
 
 class ProjectAPI(object):
 
@@ -273,6 +271,7 @@ class ProjectAPI(object):
 
         return json.loads(response.read())
 
+
     @api_error_protect
     def set_group_grade(self, group_id, course_id, activity_id, grade_value, max_grade):
         grade_data = {
@@ -316,6 +315,7 @@ class ProjectAPI(object):
         )
 
         return json.loads(response.read())
+
 
     def get_latest_workgroup_submissions_by_id(self, group_id):
         submission_list = self.get_workgroup_submissions(group_id)

--- a/group_project/upload_file.py
+++ b/group_project/upload_file.py
@@ -8,13 +8,11 @@ from django.conf import settings
 
 TRACE = True
 
-
 class UploadFile(object):
 
     _sha1_hash = None
 
-    # group_id, user_id, project_api)
-    def __init__(self, file, submission_id, project_context):
+    def __init__(self, file, submission_id, project_context):#group_id, user_id, project_api)
 
         self.file = file
         self.mimetype = mimetypes.guess_type(self.file.name)[0]
@@ -49,19 +47,12 @@ class UploadFile(object):
         try:
             location = default_storage.url(path)
         except NotImplementedError:
-            location = "file:///{}/{}".format(
-                settings.BASE_DIR,
-                default_storage.path(path)
-            )
+            location = "file:///{}/{}".format(settings.BASE_DIR, default_storage.path(path))
 
         return location
 
     def _file_storage_path(self):
-        return "group_work/{}/{}/{}".format(
-            self.group_id,
-            self.sha1,
-            self.file.name
-        )
+        return "group_work/{}/{}/{}".format(self.group_id, self.sha1, self.file.name)
 
     def save_file(self):
         path = self._file_storage_path()

--- a/group_project/utils.py
+++ b/group_project/utils.py
@@ -23,7 +23,6 @@ def load_resource(resource_path):
     resource_content = pkg_resources.resource_string(__name__, resource_path)
     return unicode(resource_content)
 
-
 def render_template(template_path, context={}):
     """
     Evaluate a template by resource path, applying the provided context
@@ -31,7 +30,6 @@ def render_template(template_path, context={}):
     template_str = load_resource(template_path)
     template = Template(template_str)
     return template.render(Context(context))
-
 
 class AttrDict(dict):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR reverts commit e7d33dea3fd9d600df0404b9fe7ca2c6c6935156.
That commit was never used in production for a year or so we tried to use it with Euclaypus upgrade but it is breaking this Xblock in studio due to 404 error.
Here is traceback
```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/preview.py", line 320, in get_preview_fragment
    fragment = module.render(preview_view, context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 193, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 2033, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1298, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 806, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 82, in author_view
    self.render_children(context, fragment, can_reorder=True, can_add=True)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/studio_editable.py", line 26, in render_children
    rendered_child = child.render(StudioEditableModule.get_preview_view_name(child), context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 193, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 2033, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1298, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 806, in render
    frag = view_fn(context)
  File "/edx/src/xblock-group-project/group_project/group_project.py", line 249, in student_view
    user_prefs = self.project_api.get_user_preferences(self.user_id)
  File "/edx/src/xblock-group-project/group_project/api_error.py", line 54, in call_api_method
    raise api_error
ApiError: ApiError 'NOT FOUND' (404)
```
@e-kolpakov FYI.