### PR TITLE
Exclude group-project block from completion calculation.

### DIFF
--- a/group_project/group_project.py
+++ b/group_project/group_project.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.utils import html
 from django.utils.translation import ugettext as _
 
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Scope, String, Dict, Float, Integer
 from xblock.fragment import Fragment
@@ -65,10 +66,11 @@ class OutsiderDisallowedError(Exception):
 @XBlock.wants('notifications')
 @XBlock.wants('courseware_parent_info')
 class GroupProjectBlock(XBlock):
+    """
+    XBlock providing a group activity project for a group of students to collaborate upon.
+    """
 
-    """
-    XBlock providing a group activity project for a group of students to collaborate upon
-    """
+    completion_mode = XBlockCompletionMode.EXCLUDED
     display_name = String(
         display_name="Display Name",
         help="This name appears in the horizontal navigation at the top of the page.",

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project',
-    version='0.1',
+    version='0.1.1',
     description='XBlock - Group Project',
     packages=['group_project'],
     install_requires=[
-        'XBlock',
+        'XBlock>=1.1',
     ],
     entry_points={
         'xblock.v1': 'group-project = group_project:GroupProjectBlock',


### PR DESCRIPTION
## [MCKIN-8826](https://edx-wiki.atlassian.net/browse/MCKIN-8826)

`group-project` needs to be excluded from completion calculation.

**JIRA tickets**: MCKIN-8826, BB-580

**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

Simple configuration change.  To test, on a solutions devstack, do the following:

1. Create a course with an HTML block under one chapter, and a group-project under another chapter.  You will need to enable group-project under Advanced Settings.
2. Complete the HTML block.
3. Run aggregators `./manage.py lms --settings=devstack run_aggregator_service`
3. Verify that the group-project is not included in the "possible" value for the aggregator blocks it is part of.

Extra credit:

1. Manually create a BlockCompletion record for the group-project block
2. Run `./manage.py lms --settings=devstack run_aggregator_service
 
**Author notes and concerns**: None

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
