### PR TITLE
[YONK-1306] Switch to ugettext_lazy to avoid issues on module load time

### DIFF
--- a/group_project/api_error.py
+++ b/group_project/api_error.py
@@ -1,7 +1,7 @@
 import json
 from urllib2 import HTTPError
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 ERROR_CODE_MESSAGES = {}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-group-project',
-    version='0.1.1',
+    version='0.1.2',
     description='XBlock - Group Project',
     packages=['group_project'],
     install_requires=[


### PR DESCRIPTION
This PR fixes a small issue that happens when this module is imported at module load time.
The solution was to replace `ugettext` with `ugettext_lazy`.

**Testing instructions:**
1. On your solutions devstack, install group work v1 xblocks and add it to some course
2. Run `paver devstack lms --fast` and check for `AppRegistryNotReady` errors that might pop up while the app boots.
 3. Clone this branch somewhere accessible by you devstack and install it on the `edxapp` venv with `pip install -e .`
4. Run `paver devstack lms --fast` and check that the `AppRegistryNotReady` errors that were caused by  group work xblocks vanished.

**Reviewers:**
- [ ] @Agrendalath